### PR TITLE
Pushed all functionality outside of individual comment to thread component

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,1 +1,1 @@
-{"projectId":"prj_maowlRziTnR1k95Tfy7qzqj38HoD","orgId":"dIhiWkmLJUcu6AyUY5b4O6CQ"}
+{"projectId":"prj_58d9fLsOZn4nMNmEFQ2d1Z7vmiGJ","orgId":"jrk6aqVs6E7kDXpkCLJsI8SI","settings":{"buildCommand":null,"devCommand":null,"outputDirectory":"dist","directoryListing":false,"rootDirectory":null,"framework":null}}

--- a/api/edit-comment.js
+++ b/api/edit-comment.js
@@ -22,6 +22,6 @@ export default async function handler(req, res) {
 
   const [rows] = await connection.query('SELECT * FROM comments WHERE uid = ?', [editedComment.uid]);
   const returnedComment = rows[0];
-  res.json(returnedComment)
+  res.json(returnedComment);
 
 }

--- a/index.html
+++ b/index.html
@@ -29,14 +29,16 @@
 </head>
 
 <body>
-  <main-card></main-card>
+  <da-penguins-thread></da-penguins-thread>
   
 
 
 <script type="module">
   import './src/x-weather.js';
   import  '@lrnwebcomponents/threaded-discussion';
-  import './src/main-card.js';
+  import './src/da-penguins-comment.js';
+  import './src/da-penguins-thread.js';
+
 </script>
 
 <!-- <threaded-discussion comment-icon="send" demo source="https://webcomponents.psu.edu/styleguide/elements/threaded-discussion/demo/discussion.json">

--- a/src/da-penguins-comment.js
+++ b/src/da-penguins-comment.js
@@ -1,7 +1,6 @@
 // dependencies / things imported
 import { html, css } from 'lit';
 import { SimpleColors } from '@lrnwebcomponents/simple-colors/simple-colors.js';
-import sjcl from 'sjcl';
 import 'jwt-auth-component';
 import '@lrnwebcomponents/simple-icon/lib/simple-icons.js';
 import '@lrnwebcomponents/simple-icon/lib/simple-icon-lite.js';
@@ -9,10 +8,10 @@ import '@lrnwebcomponents/simple-icon/lib/simple-icon-lite.js';
 // EXPORT (so make available to other documents that reference this file) a class, that extends LitElement
 
 // which has the magic life-cycles and developer experience below added
-export class maincard extends SimpleColors {
+export class DaPenguinsComment extends SimpleColors {
   // a convention I enjoy so you can change the tag name in 1 place
   static get tag() {
-    return 'main-card';
+    return 'da-penguins-comment';
   }
 
   // CSS - specific to Lit
@@ -130,33 +129,42 @@ export class maincard extends SimpleColors {
     this.answerIcon = false;
     this.icon = '';
     this.threadPermissions = null;
-    this.threadEnabled = false;
-    this.displayItems = [];
     // Gets the ID NEEDED FOR GETTING COMMENTS
-    this.threadID = this.getThreadID();
-    // handles authentication events from jwt-auth
-    this.addEventListener('auth-success', this.authsucks)
-    console.log(this.displayItems);
-  }
+    this.threadID = null;
 
-  async authsucks() {
-    this.displayItems = await this.getAllComments();
-    this.threadEnabled = true;
+    this.UID = null; 
+    this.userUID = null;
+    this.submittedTime = null;
+    this.body = null;
+    this.editedTime = null;
+    this.isEdited = false;
+    this.isReply = false;
+    this.replyTo = null;
+    this.likes = 0;
+    
   }
 
   // properties that you wish to use as data in HTML, CSS, and the updated life-cycle
   static get properties() {
     return {
       ...super.properties,
-      imgSrc: { type: String, reflect: true, attribute: 'img-src'},
-      imgKeyword: { type: String, attribute: 'img-keyword'},
+      imgSrc: { type: String, reflect: true, attribute: 'img-src' },
+      imgKeyword: { type: String, attribute: 'img-keyword' },
       status: { type: String, reflect: true }, // Correct, incorrect, pending
       answerIcon: { type: Boolean, reflect: true },
       icon: { type: String },
-      threadEnabled: {type: Boolean},
-      threadPermissions: {type: String},
-      threadID: {type: String},
-      displayItems: {type: Array },
+      threadPermissions: { type: String },
+      threadID: { type: String },
+
+      UID: { type: String },
+      userUID: { type: String },
+      submittedTime: { type: String },
+      body: { type: String },
+      editedTime: { type: String },
+      isEdited: { type: Boolean },
+      isReply: { type: Boolean },
+      replyTo: { type: String },
+      likes: { type: String }
     };
   }
 
@@ -210,18 +218,7 @@ export class maincard extends SimpleColors {
     .then((res) => res.json())
     .then((data) => {
       this.threadPermissions = data.permissions;
-    })
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  getThreadID() {
-    // the thread id is the current page hash
-    if (window.location.host === "localhost:3000"){
-      return '1234'
-    }
-    const currentPage = window.location.href;
-    const hashBits = sjcl.hash.sha256.hash(currentPage);
-    return sjcl.codec.hex.fromBits(hashBits);
+    });
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -237,101 +234,89 @@ export class maincard extends SimpleColors {
     console.log(response);
   }
 
+  // TODO: Maybe use for chaining replies to a comment? (can be thru comment.js or thread.js)
   // eslint-disable-next-line class-methods-use-this
-  async createUser(){
-    const response = await fetch('/api/create-user', {
-      method: 'POST',
-      body: JSON.stringify({
-        name: "Jimmy",
-         is_admin: false,
-      }) // body data type must match "Content-Type" header
-    }).then(res => res.json());
+  async getSpecificComment(targetUID){
+    const response = await fetch(`/api/get-comment?uid=${targetUID}`).then(res => res.json());
     console.log(response);
   }
 
 
-  // eslint-disable-next-line class-methods-use-this
-  async getAllComments(){
-    const response = await fetch('/api/get-comment').then(res => res.json());
-    return response;
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async getSpecificComments(){
-    const response = await fetch('/api/get-comment?uid=07e76fec-9f18-4b94-b464-df930de006a1').then(res => res.json());
-    console.log(response)
-  }
-
-  // eslint-disable-next-line class-methods-use-this
   async likeComment(){
     // 07e76fec-9f18-4b94-b464-df930de006a1
-    const response = await fetch('/api/like-comment?uid=07e76fec-9f18-4b94-b464-df930de006a1').then(res => res.json());
-    console.log(response)
+    const response = await fetch(`/api/like-comment?uid=${this.UID}`).then(res => res.json());
+    console.log(response);
   }
 
-  // eslint-disable-next-line class-methods-use-this
   async deleteComment(){
-    const response = await fetch('/api/delete-comment?uid=16a2761a-bbab-4707-9c3f-5f5b43f2cf18').then(res => res.json());
-    console.log(response)
+    const response = await fetch(`/api/delete-comment?uid=${this.UID}`).then(res => res.json());
+    console.log(response);
+  }
+
+  async editComment(){
+    const response = await fetch('/api/edit-comment', {
+      method: 'PUT',
+      body: JSON.stringify({
+        uid: this.UID, 
+        body: "Let's test this test",
+     })
+    }).then(res => res.json());
+    console.log(response);
+  }
+
+  showEditingPane(comment){
+    console.log(this.goFuckYourselfLint); // TODO: Delete later
+
+    return html`
+      <div class="post-main">
+          <div class="post-title">
+            <div class="profile-pic"></div>
+            <div class="title-content">
+              <div class="header">
+                <h1>${comment.user_uid}</h1>
+              </div>
+              <div class="username">
+                <simple-icon-lite icon="favorite"></simple-icon-lite>
+                <p>${comment.likes}</p>
+              </div>
+            </div>
+          </div>
+          <div class="post-body">${comment.body} ${comment.uid}</div>
+        </div>
+    `;
   }
 
   // HTML - specific to Lit
   render() {
-    if (!this.threadEnabled) {
-      // TODO: add different cases for various thread permissions
-      return html`
-        <div class="center" id="Nest">
-          <h2>Log in to see the comments!</h2>
-          <jwt-auth authendpoint="/api/auth/"></jwt-auth>
-        </div>
-      `
-    } return html`
-      ${this.getComment({user_uid: "jim1234", likes: 69420, body: "Does I works?"}, "b")}
-    
-      <div>
-        ${this.displayItems.map(
-          item => html`
-          ${this.getComment(item)}
-          `
-        )}
-      </div>
-    `;
-    
-  }
-
-  getComment(comment, thread) {
     return html`
-    <div id="Nest">
-          <div class="post-main">
-            <div class="post-title">
-              <div class="profile-pic">
+      <div id="Nest">
+        <div class="post-main">
+          <div class="post-title">
+            <div class="profile-pic"></div>
+            <div class="title-content">
+              <div class="header">
+                <h1>${this.userUID}</h1>
               </div>
-              <div class="title-content">
-                <div class="header">
-                  <h1> ${comment.user_uid} </h1>
-                </div>
-                <div class="username">
-                  <simple-icon-lite icon="favorite"> </simple-icon-lite>
-                  <p>${comment.likes}</p>
-                </div>
+              <div class="username">
+                <simple-icon-lite icon="favorite"></simple-icon-lite>
+                <p>${this.likes}</p>
+                <p>${this.submittedTime}</p>
               </div>
-            </div>
-            <div class="post-body">
-            ${comment.body}
             </div>
           </div>
-        ${this.answerIcon
-          ? html`<simple-icon-lite icon="${this.icon}"></simple-icon-lite>`
-          : ``}
-          <button @click=${this.createComment}> Create Comment</button>
-          <button @click=${this.getAllComments}>GET All Comments</button>
-          <button @click=${this.getSpecificComments}>GET Specific Comments</button>
-          <button @click=${this.likeComment}>Like Comment</button>
-          <button @click=${this.deleteComment}>Delete Comment</button>
-          <button @click=${this.createUser}>Create User</button>
+          <div class="post-body">${this.body} ${this.UID}</div>
+        </div>
+        ${this.answerIcon ? html`<simple-icon-lite icon="${this.icon}"></simple-icon-lite>` : ``}
+        
+        
+        <button @click=${this.likeComment}>Like Comment</button>
+        <button @click=${this.deleteComment}>Delete Comment</button>
+        
+        <button @click=${this.editComment}>Edit Comment</button>
       </div>
-    `;
+    `;  
   }
+
 
 
   // HAX specific callback
@@ -343,4 +328,4 @@ export class maincard extends SimpleColors {
     return new URL(`../lib/FlashCard.haxProperties.json`, import.meta.url).href;
   }
 }
-customElements.define(maincard.tag, maincard);
+customElements.define(DaPenguinsComment.tag, DaPenguinsComment);

--- a/src/da-penguins-thread.js
+++ b/src/da-penguins-thread.js
@@ -1,0 +1,280 @@
+/* eslint-disable eqeqeq */
+// dependencies / things imported
+import { LitElement, html, css } from 'lit';
+import '@lrnwebcomponents/simple-icon/lib/simple-icons.js';
+import '@lrnwebcomponents/simple-icon/lib/simple-icon-lite.js';
+import '@lrnwebcomponents/simple-colors';
+
+import './da-penguins-comment.js';
+import sjcl from 'sjcl';
+import 'jwt-auth-component';
+
+// EXPORT (so make available to other documents that reference this file) a class, that extends LitElement
+
+// which has the magic life-cycles and developer experience below added
+export class DaPenguinsThread extends LitElement {
+  // a convention I enjoy so you can change the tag name in 1 place
+  static get tag() {
+    return 'da-penguins-thread';
+  }
+
+  // CSS - specific to Lit
+  static get styles() {
+    return css`
+      /* :host {
+        display: block;
+        width: 320px;
+        height: 265px;
+      }
+
+      img {
+        display: flex;
+        margin: 25px auto auto;
+        height: 200px;
+        width: 275px;
+        border: 5px solid white;
+        border-radius: 19px;
+        box-shadow: 0 0 10px black;
+      }
+
+      .backgroundbox {
+        display: flex;
+        background-color: var(--simple-colors-default-theme-accent-4);
+        border-radius: 19px 19px 0 0;
+        height: 265px;
+        width: 320px;
+      }
+
+      .overlay {
+        position: relative;
+      }
+
+      .overlay::before {
+        content: '';
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        border: 1px;
+        border-radius: 19px 19px 0px 0px;
+      }
+
+      simple-icon-lite {
+        --simple-icon-height: 100px;
+        --simple-icon-width: 100px;
+        color: white;
+        transform: translate(-50%, -190%);
+        top: 50%;
+        left: 50%;
+        z-index: 100;
+      }
+
+      :host([status='pending']) .overlay::before {
+        display: flex;
+        background: transparent;
+      }
+
+      :host([status='correct']) .overlay::before {
+        display: flex;
+        background: green;
+        filter: opacity(0.65);
+      }
+
+      :host([status='incorrect']) .overlay::before {
+        display: flex;
+        background: red;
+        filter: opacity(0.65);
+      } */
+    `;
+  }
+
+  // overlay on div tag - wrap image in div & style div
+  // HTMLElement life-cycle, built in; use this for setting defaults
+  constructor() {
+    super();
+    this.threadID = this.getThreadID();
+    this.threadEnabled = false;
+    this.threadPermissions = null;
+    this.commentList = [];
+
+    // Auth wall
+    this.addEventListener('auth-success', this.authsucks);
+  }
+
+  // properties that you wish to use as data in HTML, CSS, and the updated life-cycle
+  static get properties() {
+    return {
+      ...super.properties,
+      threadID: { type: String },
+      threadEnabled: { type: Boolean },
+      threadPermissions: { type: String },
+      commentList: { type: Array },
+    };
+  }
+
+  // BACKEND TIE-INS (auth and threading)
+  async authsucks() {
+    this.commentList = await this.getAllComments();
+    this.threadEnabled = true;
+  }
+
+  // TODO: If this hashes the current page, how will we have multiple threads on a page (as requested for comp?)
+  // eslint-disable-next-line class-methods-use-this
+  getThreadID() {
+    // the thread id is the current page hash
+    if (window.location.host === 'localhost:3000') {
+      return '1234';
+    }
+    const currentPage = window.location.href;
+    const hashBits = sjcl.hash.sha256.hash(currentPage);
+    return sjcl.codec.hex.fromBits(hashBits);
+  }
+
+  async fetchThreadData() {
+    // throwing error bc not in db
+    const apiOrigin = window.location.origin;
+    const apiURL = new URL('/api/get-thread/', apiOrigin);
+    apiURL.searchParams.append('uid', this.threadID);
+    await fetch(apiURL)
+      .then(res => res.json())
+      .then(data => {
+        this.threadPermissions = data.permissions;
+      });
+  }
+
+  // CALLBACK FUNCTIONS
+
+  // Lit life-cycle; this fires the 1st time the element is rendered on the screen
+  // this is a sign it is safe to make calls to this.shadowRoot
+  firstUpdated(changedProperties) {
+    if (super.firstUpdated) {
+      super.firstUpdated(changedProperties);
+    }
+  }
+
+  // HTMLElement life-cycle, element has been connected to the page / added or moved
+  // this fires EVERY time the element is moved
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.threadPermissions == null) {
+      this.fetchThreadData();
+    }
+  }
+
+  // HTMLElement life-cycle, element has been removed from the page OR moved
+  // this fires every time the element moves
+  disconnectedCallback() {
+    super.disconnectedCallback();
+  }
+
+  // API CALLS
+
+  // eslint-disable-next-line class-methods-use-this
+  async createUser(){
+    const response = await fetch('/api/create-user', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: "Jimmy",
+         is_admin: false,
+      }) // body data type must match "Content-Type" header
+    }).then(res => res.json());
+    console.log(response);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async createComment(){
+    const response = await fetch('/api/submit-comment', {
+      method: 'POST',
+      body: JSON.stringify({
+        thread_uid: "1234",
+        user_uid: "jumbo",
+        body: "This is a test",
+     })
+    }).then(res => res.json());
+    console.log(response);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async getAllComments() {
+    const response = await fetch('/api/get-comment').then(res => res.json());
+    return response;
+  }
+
+  // TODO: Maybe use for chaining replies to a comment? (can be thru comment.js or thread.js)
+  // eslint-disable-next-line class-methods-use-this
+  async getSpecificComment(targetUID){
+    const response = await fetch(`/api/get-comment?uid=1d89ffaf-f8b2-4bc4-b71e-ddbc19827b66`).then(res => res.json());
+    console.log(targetUID ," ", response);
+    
+  }
+
+// eslint-disable-next-line class-methods-use-this
+  renderComment(comment) {
+    console.log("comment", comment);
+    console.log("uid: ", comment.uid);
+    console.log("all comments: ", this.commentList);
+    
+    const isEdited = comment.is_edited != '0';
+    const isReply= comment.is_reply != '0';
+
+    let submittedTime = new Date(comment.submitted_time);
+    submittedTime = `${submittedTime.toLocaleString()}`;
+
+    let editedTime = comment.edited_time;
+    if(isEdited){
+      editedTime = new Date(editedTime);
+    }
+    if(comment.is_deleted == '0'){
+      return html`
+        <da-penguins-comment
+          UID=${comment.uid}
+          userUID=${comment.user_uid}
+          submittedTime=${submittedTime}
+          body=${comment.body}
+          editedTime=${editedTime}
+          ?isEdited=${isEdited}
+          ?isReply=${isReply}
+          replyTo=${comment.reply_to}
+          likes=${comment.likes}
+          threadID=${this.threadID}
+        ></da-penguins-comment>
+      `;
+    }
+    return html``;
+    
+  }
+
+  render() {
+    if (!this.threadEnabled) {
+      // TODO: add different cases for various thread permissions
+      return html`
+        <div class="center" id="Nest">
+          <h2>Log in to see the comments!</h2>
+          <jwt-auth authendpoint="/api/auth/"></jwt-auth>
+        </div>
+      `;
+    }
+    return html`
+      <div class="buttons">
+        <button @click=${this.createComment}>Create Comment</button>
+        <button @click=${this.createUser}>Create User</button>
+        <button @click=${this.getAllComments}>GET All Comments</button>
+        <button @click=${this.getSpecificComment}> GET Specific Comment </button>
+      </div>
+      <div>
+        ${this.commentList.map(item => html` ${this.renderComment(item)} `)}
+      </div>
+    `;
+    
+  }
+
+
+  // HAX specific callback
+  // This teaches HAX how to edit and work with your web component
+  /**
+   * haxProperties integration via file reference
+   */
+  static get haxProperties() {
+    return new URL(`../lib/FlashCard.haxProperties.json`, import.meta.url).href;
+  }
+}
+customElements.define(DaPenguinsThread.tag, DaPenguinsThread);

--- a/src/legacy-thread.js
+++ b/src/legacy-thread.js
@@ -1,3 +1,6 @@
+// LEFT OVER FROM BEFORE SEPARATION OF COMMENT AND THREAD
+
+
 // dependencies / things imported
 import { LitElement, html, css } from 'lit';
 import '@lrnwebcomponents/simple-icon/lib/simple-icons.js';
@@ -7,10 +10,10 @@ import '@lrnwebcomponents/simple-colors';
 // EXPORT (so make available to other documents that reference this file) a class, that extends LitElement
 
 // which has the magic life-cycles and developer experience below added
-export class thread extends LitElement {
+export class OldThread extends LitElement {
   // a convention I enjoy so you can change the tag name in 1 place
   static get tag() {
-    return 'image-prompt';
+    return 'old-thread';
   }
 
   // CSS - specific to Lit
@@ -174,4 +177,4 @@ export class thread extends LitElement {
     return new URL(`../lib/FlashCard.haxProperties.json`, import.meta.url).href;
   }
 }
-customElements.define(thread.tag, thread);
+customElements.define(OldThread.tag, OldThread);


### PR DESCRIPTION
**What changed:** 
- FKA main-card.js, da-penguins-comment.js is now a component that renders one comment when given necessary info (shown in properties)
    - I made a lot of the JSON values for a comment properties in this so the API call is logically separated from populating the comment 
- da-penguins-thread.js now exists. It represents one instance of a threaded-discussion (so we can change the name later if desired), and uses the map() function in its render() to paint a corresponding <da-penguins-comment> for each undeleted comment in the db. 
    - I pulled the auth behavior into thread.js so someone is being tested for access to the whole thread rather than for each individual comment
    - Thread.js is what's actually retrieving the comments from the database now
    - I moved a few of the demonstration buttons to thread.js so they're always visible at the top (only the ones that logically relate to an entire thread rather than an individual comment
- legacy-thread.js is a fully-intact version of what thread.js used to be before I did all of this. I only made it in case someone needed something from that file, as I went pretty scorched earth on da-penguins-thread.js

